### PR TITLE
Update README to point to current template

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The repository was originally cloned from https://github.com/ucb-bar/chisel-temp
 To get the code, you can clone the repository that is in jlpteaching: `jlpteaching/dinocpu`.
 
 ```
-git clone https://github.com/jlpteaching/dinocpu.git
+git clone https://github.com/jlpteaching/dinocpu-wq22.git
 ```
 
 ## Overview of code


### PR DESCRIPTION
The old README had a reference to the old 32 bit DINO cpu template in its getting started section. 

This was leading to some students downloading the wrong version of the project. 